### PR TITLE
fix help function definition to be posix shell compliant

### DIFF
--- a/shocco.sh
+++ b/shocco.sh
@@ -56,7 +56,7 @@ expr -- "$*" : ".*--help" >/dev/null && {
     exit 0
 }
 
-function help {
+help() {
     cat <<EOF
 shocco.sh - Create literate-programming-style documentation for shell scripts.
 


### PR DESCRIPTION
I let the bashism slip into this patch, which breaks it when run under
ash on ubuntu (hence failing in the devstack doc job).

http://unix.stackexchange.com/questions/73750/difference-between-function-foo-and-foo
seems to indicate that this is the syntax that will work.
