### PR TITLE
rst2html should be quiet

### DIFF
--- a/shocco.sh
+++ b/shocco.sh
@@ -291,7 +291,7 @@ sed 's/^DOCS //'                             |
 
 # The current stream text is suitable for input to `markdown(1)`. It takes
 # our doc text with embedded `DIVIDER`s and outputs HTML.
-$PROCESSOR                                    |
+$PROCESSOR --quiet                           |
 
 # Now this where shit starts to get a little crazy. We use `csplit(1)` to
 # split the HTML into a bunch of individual files. The files are named


### PR DESCRIPTION
At the moment warning messages generated by the rst2html processor are
included in the resulting output. This can be avoided by calling the
rst2html processor with the --quiet parameter.
