### PR TITLE
Fix generated HTML output when using the rst2html processor

### DIFF
--- a/shocco.sh
+++ b/shocco.sh
@@ -147,6 +147,11 @@ PROCESSOR=$RST2HTML
       fi
   )}
 
+TEMPLATEFILE=$WORK/rst2html.txt
+cat > $TEMPLATEFILE <<EOF
+%(body)s
+EOF
+
 # We want to be absolutely sure we're not going to do something stupid like
 # use `.` or `/` as a work dir. Better safe than sorry.
 test -z "$WORK" -o "$WORK" = '/' && {
@@ -291,7 +296,7 @@ sed 's/^DOCS //'                             |
 
 # The current stream text is suitable for input to `markdown(1)`. It takes
 # our doc text with embedded `DIVIDER`s and outputs HTML.
-$PROCESSOR --quiet                           |
+$PROCESSOR --quiet --template $TEMPLATEFILE  |
 
 # Now this where shit starts to get a little crazy. We use `csplit(1)` to
 # split the HTML into a bunch of individual files. The files are named

--- a/shocco.sh
+++ b/shocco.sh
@@ -291,7 +291,7 @@ sed 's/^DOCS //'                             |
 
 # The current stream text is suitable for input to `markdown(1)`. It takes
 # our doc text with embedded `DIVIDER`s and outputs HTML.
-$PROCESSOR                                    |
+$PROCESSOR --quiet                           |
 
 # Now this where shit starts to get a little crazy. We use `csplit(1)` to
 # split the HTML into a bunch of individual files. The files are named


### PR DESCRIPTION
This PR will fix two issues. Please have a look at http://docs.openstack.org/developer/devstack/lib/dstat.html for the issues.

The first issue is that at the moment warning messages generated by the rst2html processor are included into the resulting output (e.g. `System Message: WARNING/2 (<stdin>, line 34) Definition list ends without a blank line; unexpected unindent.`).

The second issue is that there are two HTML headers in the output of the shocco script.
